### PR TITLE
Add jade fixtures support

### DIFF
--- a/gulp/tasks/jade.coffee
+++ b/gulp/tasks/jade.coffee
@@ -10,6 +10,7 @@ prettify     = require 'gulp-prettify'
 pkg          = require '../../package.json'
 errorHandler = require '../utils/errorHandler'
 paths        = require '../paths'
+fixture      = require '../utils/fixture'
 
 gulp.task 'jade', ->
 	gulp.src 'app/templates/**/*.jade'
@@ -19,6 +20,7 @@ gulp.task 'jade', ->
 		.pipe filter (file) -> /templates[\\\/]pages/.test file.path
 		.pipe jade
 			data:
+				fixture: fixture
 				page:
 					copyright: pkg.copyright
 					description: pkg.description

--- a/gulp/utils/fixture.coffee
+++ b/gulp/utils/fixture.coffee
@@ -1,0 +1,12 @@
+path = require 'path'
+fs   = require 'fs'
+
+exports.get = (datafile) ->
+
+	fixtursPath = (path.resolve (path.join '.', 'app', 'resources', 'fixtures')) + path.sep
+	datafilePath = path.resolve path.join fixtursPath, datafile + '.json'
+
+	if fixtursPath != datafilePath.slice 0, fixtursPath.length
+		throw new Error 'Fixture path is not in fixtures directory. Abort due potential data disclosure.'
+
+	return JSON.parse fs.readFileSync datafilePath


### PR DESCRIPTION
С этой штукой можно легко использовать фикстуры изнутри jade

```jade
each field in fixture.get('block/fakefields')
   .some= field.name
   .another= field.description
```