### PR TITLE
fix(gulpfile): change babel/register to babel-core/register

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,2 +1,2 @@
-require('babel/register');
+require('babel-core/register');
 require('require-dir')('./gulp/tasks', {recurse: true});


### PR DESCRIPTION
Была ошибка при запуске проекта:
```
Error: Cannot find module 'babel/register'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:278:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/Users/kuflash/projects/aws.by/gulpfile.js:1:63)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
```