### PR TITLE
Пофиксил остановку отслеживания изменений в js файлах после ошибки линтера

### DIFF
--- a/gulp/scripts.js
+++ b/gulp/scripts.js
@@ -57,7 +57,7 @@ function runWebpack(watch = false) {
 		],
 		eslint: {
 			configFile: path.join(__dirname, '../.eslintrc'),
-			emitError: true,
+			emitError: false,
 			emitWarning: true,
 			formatter: errors => {
 				if (errors[0].messages) {


### PR DESCRIPTION
Из-за исправления [проблемы в eslint-loader](https://github.com/MoOx/eslint-loader/pull/29#issuecomment-89949362) eslint прерывал отслеживание изменений.